### PR TITLE
Where in patch

### DIFF
--- a/src/Granada/ORM.php
+++ b/src/Granada/ORM.php
@@ -1236,6 +1236,9 @@ class ORM implements ArrayAccess {
      * Add a WHERE ... IN clause to your query
      */
     public function where_in($column_name, $values) {
+        if (!$values) {
+            return $this->_add_where("0", $values);
+        }
         $column_name = $this->_quote_identifier($column_name);
         $placeholders = $this->_create_placeholders($values);
         return $this->_add_where("{$column_name} IN ({$placeholders})", $values);
@@ -1247,9 +1250,11 @@ class ORM implements ArrayAccess {
      * @param string[] $values
      */
     public function where_not_in($column_name, $values) {
-        $column_name = $this->_quote_identifier($column_name);
-        $placeholders = $this->_create_placeholders($values);
-        return $this->_add_where("{$column_name} NOT IN ({$placeholders})", $values);
+        if ($values) {
+            $column_name = $this->_quote_identifier($column_name);
+            $placeholders = $this->_create_placeholders($values);
+            return $this->_add_where("{$column_name} NOT IN ({$placeholders})", $values);
+        }
     }
 
     /**

--- a/src/Granada/ORM.php
+++ b/src/Granada/ORM.php
@@ -1255,6 +1255,7 @@ class ORM implements ArrayAccess {
             $placeholders = $this->_create_placeholders($values);
             return $this->_add_where("{$column_name} NOT IN ({$placeholders})", $values);
         }
+        return $this;
     }
 
     /**

--- a/tests/orm/QueryBuilderTest.php
+++ b/tests/orm/QueryBuilderTest.php
@@ -78,9 +78,21 @@ class QueryBuilderTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals($expected, ORM::get_last_query());
     }
 
+    public function testWhereInNoItems() {
+        ORM::for_table('widget')->where_in('name', array())->find_many();
+        $expected = "SELECT * FROM `widget` WHERE 0";
+        $this->assertEquals($expected, ORM::get_last_query());
+    }
+
     public function testWhereNotIn() {
         ORM::for_table('widget')->where_not_in('name', array('Fred', 'Joe'))->find_many();
         $expected = "SELECT * FROM `widget` WHERE `name` NOT IN ('Fred', 'Joe')";
+        $this->assertEquals($expected, ORM::get_last_query());
+    }
+
+    public function testWhereNotInNoItems() {
+        ORM::for_table('widget')->where_not_in('name', array())->find_many();
+        $expected = "SELECT * FROM `widget`";
         $this->assertEquals($expected, ORM::get_last_query());
     }
 


### PR DESCRIPTION
If a where_in or where_not_in function is called with an empty array, the SQL query generated has an error as it is expanded to WHERE IN () and WHERE NOT IN ()

This patch includes a test, if the array is empty the where_in function adds WHERE 0 to the query, and the where_not_in does not add to the query as it has no effect.

This patch includes phpunit tests for the conditions.