### PR TITLE
Fix id set on save when id is sent as a blank field

### DIFF
--- a/src/Granada/ORM.php
+++ b/src/Granada/ORM.php
@@ -1919,7 +1919,7 @@ class ORM implements ArrayAccess {
         // If we've just inserted a new record, set the ID of this object
         if ($this->_is_new) {
             $this->_is_new = false;
-            if (is_null($this->id())) {
+            if (!($this->id())) {
                 if(self::$_db[$this->_connection_name]->getAttribute(PDO::ATTR_DRIVER_NAME) == 'pgsql') {
                     $this->_data[$this->_get_id_column_name()] = self::get_last_statement()->fetchColumn();
                 } else {

--- a/src/Granada/ORM.php
+++ b/src/Granada/ORM.php
@@ -1151,6 +1151,9 @@ class ORM implements ArrayAccess {
      * is built.
      */
     public function where($column_name, $value) {
+		if (is_null($value)) {
+			return $this->where_null($column_name);
+		}
         return $this->where_equal($column_name, $value);
     }
 
@@ -1159,6 +1162,9 @@ class ORM implements ArrayAccess {
      * Can be used if preferred.
      */
     public function where_equal($column_name, $value) {
+		if (is_null($value)) {
+			return $this->where_null($column_name);
+		}
         return $this->_add_simple_where($column_name, '=', $value);
     }
 
@@ -1168,6 +1174,9 @@ class ORM implements ArrayAccess {
      * @param string $value
      */
     public function where_not_equal($column_name, $value) {
+		if (is_null($value)) {
+			return $this->where_not_null($column_name);
+		}
         return $this->_add_simple_where($column_name, '!=', $value);
     }
 

--- a/tests/granada/GranadaNewTest.php
+++ b/tests/granada/GranadaNewTest.php
@@ -60,6 +60,25 @@ class GranadaNewTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals($expected, $car->name);
     }
 
+    public function testNewItemNoID(){
+    	$car = Model::factory('Car')->create(array(
+            'name' => 'New Car',
+        ));
+        $car->save();
+    	$expected = 5;
+        $this->assertEquals($expected, $car->id);
+    }
+
+    public function testNewItemBlankID(){
+    	$car = Model::factory('Car')->create(array(
+            'id' => '',
+            'name' => 'New Car',
+        ));
+        $car->save();
+    	$expected = 9;
+        $this->assertEquals($expected, $car->id);
+    }
+
     public function testSetterForRelationship(){
     	$car = Model::factory('Car')->with('manufactor')->find_one(1);
     	$expected = 'Manufactor1';

--- a/tests/orm/QueryBuilderTest.php
+++ b/tests/orm/QueryBuilderTest.php
@@ -48,6 +48,42 @@ class QueryBuilderTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals($expected, ORM::get_last_query());
     }
 
+    public function testSingleWhereClauseEqEmpty() {
+        ORM::for_table('widget')->where('name', '')->find_one();
+        $expected = "SELECT * FROM `widget` WHERE `name` = '' LIMIT 1";
+        $this->assertEquals($expected, ORM::get_last_query());
+    }
+
+    public function testSingleWhereClauseEqNULL() {
+        ORM::for_table('widget')->where('name', NULL)->find_one();
+        $expected = "SELECT * FROM `widget` WHERE `name` IS NULL LIMIT 1";
+        $this->assertEquals($expected, ORM::get_last_query());
+    }
+
+    public function testSingleWhereEqualsClauseEqNULL() {
+        ORM::for_table('widget')->where_equal('name', NULL)->find_one();
+        $expected = "SELECT * FROM `widget` WHERE `name` IS NULL LIMIT 1";
+        $this->assertEquals($expected, ORM::get_last_query());
+    }
+
+    public function testSingleWhereNotEqNULL() {
+        ORM::for_table('widget')->where_not_equal('name', NULL)->find_one();
+        $expected = "SELECT * FROM `widget` WHERE `name` IS NOT NULL LIMIT 1";
+        $this->assertEquals($expected, ORM::get_last_query());
+    }
+
+    public function testMultipleWhereNULLClauses() {
+        ORM::for_table('widget')->where('name', NULL)->where('age', NULL)->find_one();
+        $expected = "SELECT * FROM `widget` WHERE `name` IS NULL AND `age` IS NULL LIMIT 1";
+        $this->assertEquals($expected, ORM::get_last_query());
+    }
+
+    public function testMultipleWhereClausesOneNULL() {
+        ORM::for_table('widget')->where('name', 'Fred')->where('age', NULL)->find_one();
+        $expected = "SELECT * FROM `widget` WHERE `name` = 'Fred' AND `age` IS NULL LIMIT 1";
+        $this->assertEquals($expected, ORM::get_last_query());
+    }
+
     public function testMultipleWhereClauses() {
         ORM::for_table('widget')->where('name', 'Fred')->where('age', 10)->find_one();
         $expected = "SELECT * FROM `widget` WHERE `name` = 'Fred' AND `age` = '10' LIMIT 1";


### PR DESCRIPTION
When an id field is set in a new record but it's blank rather than numeric, the ORM should overwrite the value with the auto-increment field value.

This pull request includes a test case for the action. I didn't quite understand how the testing gets the id it does, but when it fails it is not numeric. Maybe there's a better test case?
