### PR TITLE
Add auto-detection of NULL fields and use IS NULL instead of =

### DIFF
--- a/src/Granada/ORM.php
+++ b/src/Granada/ORM.php
@@ -1151,6 +1151,9 @@ class ORM implements ArrayAccess {
      * is built.
      */
     public function where($column_name, $value) {
+		if (is_null($value)) {
+			return $this->where_null($column_name);
+		}
         return $this->where_equal($column_name, $value);
     }
 
@@ -1159,6 +1162,9 @@ class ORM implements ArrayAccess {
      * Can be used if preferred.
      */
     public function where_equal($column_name, $value) {
+		if (is_null($value)) {
+			return $this->where_null($column_name);
+		}
         return $this->_add_simple_where($column_name, '=', $value);
     }
 
@@ -1168,6 +1174,9 @@ class ORM implements ArrayAccess {
      * @param string $value
      */
     public function where_not_equal($column_name, $value) {
+		if (is_null($value)) {
+			return $this->where_not_null($column_name);
+		}
         return $this->_add_simple_where($column_name, '!=', $value);
     }
 

--- a/tests/orm/QueryBuilderTest.php
+++ b/tests/orm/QueryBuilderTest.php
@@ -48,6 +48,42 @@ class QueryBuilderTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals($expected, ORM::get_last_query());
     }
 
+    public function testSingleWhereClauseEqEmpty() {
+        ORM::for_table('widget')->where('name', '')->find_one();
+        $expected = "SELECT * FROM `widget` WHERE `name` = '' LIMIT 1";
+        $this->assertEquals($expected, ORM::get_last_query());
+    }
+
+    public function testSingleWhereClauseEqNULL() {
+        ORM::for_table('widget')->where('name', NULL)->find_one();
+        $expected = "SELECT * FROM `widget` WHERE `name` IS NULL LIMIT 1";
+        $this->assertEquals($expected, ORM::get_last_query());
+    }
+
+    public function testSingleWhereEqualsClauseEqNULL() {
+        ORM::for_table('widget')->where_equal('name', NULL)->find_one();
+        $expected = "SELECT * FROM `widget` WHERE `name` IS NULL LIMIT 1";
+        $this->assertEquals($expected, ORM::get_last_query());
+    }
+
+    public function testSingleWhereNotEqNULL() {
+        ORM::for_table('widget')->where_not_equal('name', NULL)->find_one();
+        $expected = "SELECT * FROM `widget` WHERE `name` IS NOT NULL LIMIT 1";
+        $this->assertEquals($expected, ORM::get_last_query());
+    }
+
+    public function testMultipleWhereNULLClauses() {
+        ORM::for_table('widget')->where('name', NULL)->where('age', NULL)->find_one();
+        $expected = "SELECT * FROM `widget` WHERE `name` IS NULL AND `age` IS NULL LIMIT 1";
+        $this->assertEquals($expected, ORM::get_last_query());
+    }
+
+    public function testMultipleWhereClausesOneNULL() {
+        ORM::for_table('widget')->where('name', 'Fred')->where('age', NULL)->find_one();
+        $expected = "SELECT * FROM `widget` WHERE `name` = 'Fred' AND `age` IS NULL LIMIT 1";
+        $this->assertEquals($expected, ORM::get_last_query());
+    }
+
     public function testMultipleWhereClauses() {
         ORM::for_table('widget')->where('name', 'Fred')->where('age', 10)->find_one();
         $expected = "SELECT * FROM `widget` WHERE `name` = 'Fred' AND `age` = '10' LIMIT 1";


### PR DESCRIPTION
When you have a variable to compare for a nullable field, it's good to be able to use a single query setup rather than use explicit code.
For example:
`$models = Model::where('type_id', $type)->where('enabled', 1)->find_many();`

If $type is NULL or a number you previously had to write handle the logic manually and use where_null() instead of where(). This patch adds code to where(), where_equal() and where_not_equal() to use NULL and NOT NULL if the variable is NULL.

Patch includes phpunit tests
