### PR TITLE
Add function to list the dirty fields

### DIFF
--- a/src/Granada/Granada.php
+++ b/src/Granada/Granada.php
@@ -510,6 +510,13 @@ use ArrayAccess;
         }
 
         /**
+         * Get the list of fields that need updating on next save
+         */
+        public function list_dirty_fields() {
+            return $this->orm->list_dirty_fields();
+        }
+
+        /**
          * Check whether the model was the result of a call to create() or not
          * @return bool
          */

--- a/src/Granada/ORM.php
+++ b/src/Granada/ORM.php
@@ -1885,6 +1885,14 @@ class ORM implements ArrayAccess {
     }
 
     /**
+     * List the dirty fields that need updating on next save
+	 *
+     */
+    public function list_dirty_fields() {
+        return $this->_dirty_fields;
+    }
+
+    /**
      * Check whether the model was the result of a call to create() or not
      * @return bool
      */


### PR DESCRIPTION
I needed to access the list of dirty fields from userspace, so e.g. I can prohibit updating the updated_at field if an unnecessary field like last_online is changed. Adding this function is quicker than iterating through the attribute list and doing an is_dirty() test on each one.