### PR TITLE
find_pairs to support select expressions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: php
 php:
-  - 5.3
-  - 5.4
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
 script: "phpunit --colors --coverage-text --coverage-clover=coverage.clover"
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,8 @@
     },
     "autoload": {
         "psr-0": {"Granada": "src/"}
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^5.6|^7.3"
     }
 }

--- a/src/Granada/Orm/Wrapper.php
+++ b/src/Granada/Orm/Wrapper.php
@@ -253,6 +253,10 @@ class Wrapper extends ORM {
     {
         $key = ($key) ? $key : 'id';
         $value = ($value) ? $value : 'name';
+        if (count($this->_result_columns) == 2) {
+            // The select fields have already been set
+            return self::assoc_to_keyval($this->find_array(), $key, $value);
+        }
         return self::assoc_to_keyval($this->select_raw("$key,$value")->order_by_asc($value)->find_array(), $key, $value);
     }
 

--- a/src/Granada/Orm/Wrapper.php
+++ b/src/Granada/Orm/Wrapper.php
@@ -275,7 +275,7 @@ class Wrapper extends ORM {
     {
         if(empty($assoc) OR empty($key_field) OR empty($val_field))
         {
-            return null;
+            return array();
         }
 
         $output = array();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,6 @@
 <?php
 
+
 include __DIR__ . '/../src/Granada/ORM.php';
 include __DIR__ . '/../src/Granada/Orm/Wrapper.php';
 include __DIR__ . '/../src/Granada/Orm/Str.php';
@@ -9,3 +10,7 @@ include __DIR__ . '/../src/Granada/Model.php';
 include __DIR__ . '/../src/Granada/ResultSet.php';
 include __DIR__ . '/MockPDO.php';
 include __DIR__ . '/models.php';
+
+// Handle both PHP5 and PHP7 tests
+if (!class_exists('\PHPUnit_Framework_TestCase') && class_exists('\PHPUnit\Framework\TestCase'))
+    class_alias('\PHPUnit\Framework\TestCase', '\PHPUnit_Framework_TestCase');

--- a/tests/granada/GranadaNewTest.php
+++ b/tests/granada/GranadaNewTest.php
@@ -117,6 +117,86 @@ class GranadaNewTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals($expected, $pairs);
     }
 
+    public function testfindPairsOrdered(){
+        $pairs = car::order_by_desc('id')->find_pairs();
+        $expected = array(
+            '4' => 'Car4',
+            '3' => 'Car3',
+            '2' => 'Car2',
+            '1' => 'Car1',
+        );
+        $this->assertequals($expected, $pairs);
+    }
+
+    public function testfindpairsforceselect(){
+        $pairs = car::select('id')->select('manufactor_id', 'name')->find_pairs();
+        $expected = array(
+            '1' => '1',
+            '2' => '1',
+            '3' => '2',
+            '4' => '2',
+        );
+        $this->assertequals($expected, $pairs);
+    }
+
+    public function testfindPairsWithJoin(){
+        $pairs = Car::join('manufactor', 'manufactor.id=car.manufactor_id')
+            ->select('car.name', 'car_name')
+            ->select('manufactor.name', 'manufactor_name')
+            ->find_pairs('car_name', 'manufactor_name');
+        $expected = array(
+            'Car1' => 'Manufactor1',
+            'Car2' => 'Manufactor1',
+            'Car3' => 'Manufactor2',
+            'Car4' => 'Manufactor2',
+        );
+        $this->assertEquals($expected, $pairs);
+    }
+
+    public function testfindPairsWithJoinIDName(){
+        $pairs = Car::join('manufactor', 'manufactor.id=car.manufactor_id')
+            ->select('car.name', 'id')
+            ->select('manufactor.name', 'name')
+            ->find_pairs();
+        $expected = array(
+            'Car1' => 'Manufactor1',
+            'Car2' => 'Manufactor1',
+            'Car3' => 'Manufactor2',
+            'Car4' => 'Manufactor2',
+        );
+        $this->assertEquals($expected, $pairs);
+    }
+
+    public function testfindPairsWithJoinOrdered(){
+        $pairs = Car::join('manufactor', 'manufactor.id=car.manufactor_id')
+            ->select('car.name', 'car_name')
+            ->select('manufactor.name', 'manufactor_name')
+            ->order_by_desc('car.name')
+            ->find_pairs('car_name', 'manufactor_name');
+        $expected = array(
+            'Car4' => 'Manufactor2',
+            'Car3' => 'Manufactor2',
+            'Car2' => 'Manufactor1',
+            'Car1' => 'Manufactor1',
+        );
+        $this->assertEquals($expected, $pairs);
+    }
+
+    public function testfindPairsWithJoinExpr(){
+        $pairs = Car::join('manufactor', 'manufactor.id=car.manufactor_id')
+            ->join('owner', 'owner.id=car.owner_id')
+            ->select('car.name', 'car_name')
+            ->select_expr('manufactor.name || " " || owner.name', 'manufactor_name') // For MySQL select_expr('CONCAT(manufactor.name, " ", owner.name)', 'manufactor_name')
+            ->find_pairs('car_name', 'manufactor_name');
+        $expected = array(
+            'Car1' => 'Manufactor1 Owner1',
+            'Car2' => 'Manufactor1 Owner2',
+            'Car3' => 'Manufactor2 Owner3',
+            'Car4' => 'Manufactor2 Owner4',
+        );
+        $this->assertEquals($expected, $pairs);
+    }
+
     public function testNoResultsfindPairs(){
         $pairs = Car::where('id',10)->find_pairs('id', 'name');
         $this->assertNull($pairs);

--- a/tests/granada/GranadaNewTest.php
+++ b/tests/granada/GranadaNewTest.php
@@ -199,7 +199,12 @@ class GranadaNewTest extends PHPUnit_Framework_TestCase {
 
     public function testNoResultsfindPairs(){
         $pairs = Car::where('id',10)->find_pairs('id', 'name');
-        $this->assertNull($pairs);
+        $this->assertEquals(array(), $pairs);
+    }
+
+    public function testNoResultsfindMany(){
+        $cars = Car::where('id',10)->find_many();
+        $this->assertEquals(0, count($cars));
     }
 
     public function testfilters(){


### PR DESCRIPTION
Currently the find_pairs function forces pulling two single fields from a table. A slight adjustment allows for using select_expr() to set each field, so allows for powerful joins, concats etc to be quickly pulled from the database and placed into a pair array.
I have included samples of how it can be used as test cases